### PR TITLE
chore: change CODEOWNERS from agglayer to sebastiendan

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,4 +4,4 @@
 ############################################################################
 
 # Default owners, unless a later match takes precedence.
-* @agglayer/agglayer-infra
+* sebastiendan


### PR DESCRIPTION
This PR updates the CODEOWNERS to remove the agglayer-infra team and set me instead, so that dependabot reviews are only assigned to me.